### PR TITLE
Implements multi-task classification prediction with the optional ability to ignore left out values

### DIFF
--- a/fairseq/criterions/multi_sentence_prediction.py
+++ b/fairseq/criterions/multi_sentence_prediction.py
@@ -1,0 +1,149 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+import torch
+import torch.nn.functional as F
+
+from fairseq import metrics
+from fairseq.criterions import FairseqCriterion, register_criterion
+from fairseq.dataclass import FairseqDataclass
+
+
+@dataclass
+class MultiSentencePredictionConfig(FairseqDataclass):
+    ignore_str: Optional[str] = field(default="",  metadata={"help": "str to ignore"})
+    classification_head_name: str = field(
+        default="sentence_classification_head",
+        metadata={"help": "name of the classification head to use"},
+    )
+    number_of_targets: int = field(default=-1,  metadata={"help": "number of the classification heads to use"})
+
+
+@register_criterion("multi_sentence_prediction", dataclass=MultiSentencePredictionConfig)
+class SentencePredictionCriterion(FairseqCriterion):
+    def __init__(self, cfg: MultiSentencePredictionConfig, task):
+        super().__init__(task)
+        self.classification_head_name: str = cfg.classification_head_name
+        self.number_of_targets: int = cfg.number_of_targets
+
+        self.ignore_index: int = (self.task.label_dictionary.index(cfg.ignore_str.strip()) if (
+            cfg.ignore_str is not None and len(cfg.ignore_str) > 0) else -100)
+        print(f"Ignoring Index {self.ignore_index} for string {cfg.ignore_str}")
+        assert self.number_of_targets > 0
+
+    def forward(self, model, sample, reduce=True):
+        """Compute the loss for the given sample.
+
+        Returns a tuple with three elements:
+        1) the loss
+        2) the sample size, which is used as the denominator for the gradient
+        3) logging outputs to display while training
+        """
+        aggregate_loss = 0
+        logging_output = {}
+        sample_size = None
+        for target_index in range(self.number_of_targets):
+            classification_head = f"{self.classification_head_name}{target_index}"
+            assert (
+                hasattr(model, "classification_heads")
+                and classification_head in model.classification_heads
+            ), f"model must provide correct head not {classification_head}"
+
+            logits, _ = model(
+                **sample["net_input"],
+                features_only=True,
+                classification_head_name=classification_head,
+            )
+            targets = sample["target"][str(target_index)].view(-1)
+            sample_size = targets.numel()
+
+            lprobs = F.log_softmax(logits, dim=-1, dtype=torch.float32)
+            task_loss = F.nll_loss(lprobs, targets, reduction="sum", ignore_index=self.ignore_index)
+
+            loss = task_loss
+            # mha & ffn regularization update
+            if (
+                hasattr(model.args, "mha_reg_scale_factor")
+                and model.args.mha_reg_scale_factor != 0.0
+            ):
+                mha_reg_loss = model._get_adaptive_head_loss()
+                loss += mha_reg_loss
+                logging_output.update({"mha_reg_loss": mha_reg_loss})
+            if (
+                hasattr(model.args, "ffn_reg_scale_factor")
+                and model.args.ffn_reg_scale_factor != 0.0
+            ):
+                ffn_reg_loss = model._get_adaptive_ffn_loss()
+                loss += ffn_reg_loss
+                logging_output.update({"ffn_reg_loss": ffn_reg_loss})
+
+            aggregate_loss += loss
+
+            preds = logits.argmax(dim=1)
+            logging_output[f"ncorrect_{target_index}"] = (preds == targets).sum()
+
+        logging_output.update(
+            {
+                "loss": aggregate_loss.data,
+                "ntokens": sample["ntokens"],
+                "nsentences": sample_size,
+                "sample_size": sample_size,
+            })
+        return aggregate_loss, sample_size, logging_output
+
+    @staticmethod
+    def reduce_metrics(logging_outputs) -> None:
+        """Aggregate logging outputs from data parallel training."""
+        loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
+        ntokens = sum(log.get("ntokens", 0) for log in logging_outputs)
+        nsentences = sum(log.get("nsentences", 0) for log in logging_outputs)
+        sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
+        mha_reg_loss_sum = sum(log.get("mha_reg_loss", 0) for log in logging_outputs)
+        ffn_reg_loss_sum = sum(log.get("ffn_reg_loss", 0) for log in logging_outputs)
+
+        metrics.log_scalar(
+            "loss", loss_sum / sample_size / math.log(2), sample_size, round=3
+        )
+        if mha_reg_loss_sum:
+            metrics.log_scalar(
+                "mha_reg_loss",
+                mha_reg_loss_sum / sample_size / math.log(2),
+                sample_size,
+                round=3,
+            )
+        if ffn_reg_loss_sum:
+            metrics.log_scalar(
+                "ffn_reg_loss",
+                ffn_reg_loss_sum / sample_size / math.log(2),
+                sample_size,
+                round=3,
+            )
+        if sample_size != ntokens:
+            metrics.log_scalar(
+                "nll_loss", loss_sum / ntokens / math.log(2), ntokens, round=3
+            )
+
+        if len(logging_outputs) > 0:
+            current_index = 0
+            current_correct = f"ncorrect_{current_index}"
+            while current_correct in logging_outputs[0]:
+                ncorrect = sum(log.get(current_correct, 0) for log in logging_outputs)
+                metrics.log_scalar(
+                    f"accuracy_{current_index}", 100.0 * ncorrect / nsentences, nsentences, round=1
+                )
+                current_index += 1
+                current_correct = f"ncorrect_{current_index}"
+
+    @staticmethod
+    def logging_outputs_can_be_summed() -> bool:
+        """
+        Whether the logging outputs returned by `forward` can be summed
+        across workers prior to calling `reduce_metrics`. Setting this
+        to True will improves distributed training speed.
+        """
+        return True

--- a/fairseq/tasks/multi_sentence_prediction.py
+++ b/fairseq/tasks/multi_sentence_prediction.py
@@ -1,0 +1,263 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Optional, List
+from omegaconf import MISSING, II, open_dict, OmegaConf
+
+import numpy as np
+from fairseq.data import (
+    ConcatSentencesDataset,
+    Dictionary,
+    IdDataset,
+    NestedDictionaryDataset,
+    NumelDataset,
+    NumSamplesDataset,
+    OffsetTokensDataset,
+    PrependTokenDataset,
+    RawLabelDataset,
+    RightPadDataset,
+    RollDataset,
+    SortDataset,
+    StripTokenDataset,
+    data_utils,
+)
+from fairseq.data.shorten_dataset import maybe_shorten_dataset
+from fairseq.tasks import FairseqDataclass, FairseqTask, register_task
+from fairseq.dataclass import ChoiceEnum
+
+
+logger = logging.getLogger(__name__)
+SHORTEN_METHOD_CHOICES = ChoiceEnum(["none", "truncate", "random_crop"])
+
+
+@dataclass
+class MultiSentencePredictionConfig(FairseqDataclass):
+    data: str = field(default=MISSING, metadata={"help": "path to data directory"})
+    num_classes: str = field(
+        default="[-1]",
+        metadata={"help": "number of classes per multi-target"},
+    )
+    init_token: Optional[int] = field(
+        default=None,
+        metadata={"help": "add token at the beginning of each batch item"},
+    )
+    separator_token: Optional[int] = field(
+        default=None,
+        metadata={"help": "add separator token between inputs"},
+    )
+    no_shuffle: bool = field(
+        default=False,
+    )
+    shorten_method: SHORTEN_METHOD_CHOICES = field(
+        default="none",
+        metadata={
+            "help": "if not none, shorten sequences that exceed tokens_per_sample"
+        },
+    )
+    shorten_data_split_list: str = field(
+        default="",
+        metadata={
+            "help": "comma-separated list of dataset splits to apply shortening to, "
+            'e.g., "train,valid" (default: all dataset splits)'
+        },
+    )
+    add_prev_output_tokens: bool = field(
+        default=False,
+        metadata={
+            "help": "add prev_output_tokens to sample, used for encoder-decoder arch"
+        },
+    )
+    max_positions: int = field(
+        default=512,
+        metadata={"help": "max tokens per example"},
+    )
+    classification_head_name: str = II("criterion.classification_head_name")
+    seed: int = II("common.seed")
+
+
+@register_task("multi_sentence_prediction", dataclass=MultiSentencePredictionConfig)
+class MultiSentencePredictionTask(FairseqTask):
+    """
+    Sentence (or sentence pair) prediction (classification or regression) task.
+
+    Args:
+        dictionary (Dictionary): the dictionary for the input of the task
+    """
+
+    def __init__(self, cfg, data_dictionary, label_dictionary, num_classes: List[int]):
+        super().__init__(cfg)
+        self.dictionary = data_dictionary
+        self._label_dictionary = label_dictionary
+        self.num_classes = num_classes
+
+    @classmethod
+    def load_dictionary(cls, filename):
+        """Load the dictionary from the filename
+
+        Args:
+            filename (str): the filename
+        """
+        dictionary = Dictionary.load(filename)
+        dictionary.add_symbol("<mask>")
+        return dictionary
+
+    @classmethod
+    def setup_task(cls, cfg, **kwargs):
+        assert len(cfg.num_classes) > 0, "Must set task.num_classes"
+        num_classes = list(map(int, cfg.num_classes[1:-1].split(",")))
+        logger.info(f"[number of targets]: {num_classes}")
+        for num_class in num_classes:
+            assert num_class > 0, "Must set task.num_classes"
+
+        # load data dictionary
+        data_dict = cls.load_dictionary(
+            os.path.join(cfg.data, "input0", "dict.txt"),
+        )
+        logger.info("[input] dictionary: {} types".format(len(data_dict)))
+
+        label_dict = cls.load_dictionary(
+            os.path.join(cfg.data, "label0", "dict.txt"),
+        )
+        logger.info("[label] dictionary: {} types".format(len(label_dict)))
+        return cls(cfg, data_dict, label_dict, num_classes)
+
+    def load_dataset(self, split, combine=False, **kwargs):
+        """Load a given dataset split (e.g., train, valid, test)."""
+
+        def get_path(key, split):
+            return os.path.join(self.cfg.data, key, split)
+
+        def make_dataset(key, dictionary):
+            split_path = get_path(key, split)
+
+            try:
+                dataset = data_utils.load_indexed_dataset(
+                    split_path,
+                    dictionary,
+                    combine=combine,
+                )
+            except Exception as e:
+                if "StorageException: [404] Path not found" in str(e):
+                    logger.warning(f"dataset {e} not found")
+                    dataset = None
+                else:
+                    raise e
+            return dataset
+
+        input0 = make_dataset("input0", self.source_dictionary)
+        assert input0 is not None, "could not find dataset: {}".format(
+            get_path("input0", split)
+        )
+        input1 = make_dataset("input1", self.source_dictionary)
+
+        if self.cfg.init_token is not None:
+            input0 = PrependTokenDataset(input0, self.cfg.init_token)
+
+        if input1 is None:
+            src_tokens = input0
+        else:
+            if self.cfg.separator_token is not None:
+                input1 = PrependTokenDataset(input1, self.cfg.separator_token)
+
+            src_tokens = ConcatSentencesDataset(input0, input1)
+
+        with data_utils.numpy_seed(self.cfg.seed):
+            shuffle = np.random.permutation(len(src_tokens))
+
+        src_tokens = maybe_shorten_dataset(
+            src_tokens,
+            split,
+            self.cfg.shorten_data_split_list,
+            self.cfg.shorten_method,
+            self.max_positions(),
+            self.cfg.seed,
+        )
+
+        dataset = {
+            "id": IdDataset(),
+            "net_input": {
+                "src_tokens": RightPadDataset(
+                    src_tokens,
+                    pad_idx=self.source_dictionary.pad(),
+                ),
+                "src_lengths": NumelDataset(src_tokens, reduce=False),
+            },
+            "nsentences": NumSamplesDataset(),
+            "ntokens": NumelDataset(src_tokens, reduce=True),
+        }
+
+        if self.cfg.add_prev_output_tokens:
+            prev_tokens_dataset = RightPadDataset(
+                RollDataset(src_tokens, 1),
+                pad_idx=self.dictionary.pad(),
+            )
+            dataset["net_input"].update(
+                prev_output_tokens=prev_tokens_dataset,
+            )
+        all_target_datasets = {}
+        for i, cur_dataset_size in enumerate(self.num_classes):
+            label_dataset = make_dataset(f"label{i}", self.label_dictionary)
+            cur_dataset = OffsetTokensDataset(
+                StripTokenDataset(
+                    label_dataset,
+                    id_to_strip=self.label_dictionary.eos(),
+                ),
+                offset=-self.label_dictionary.nspecial,
+            )
+            all_target_datasets[str(i)] = cur_dataset
+
+        dataset.update(target=all_target_datasets)
+        nested_dataset = NestedDictionaryDataset(
+            dataset,
+            sizes=[src_tokens.sizes],
+        )
+
+        if self.cfg.no_shuffle:
+            dataset = nested_dataset
+        else:
+            dataset = SortDataset(
+                nested_dataset,
+                # shuffle
+                sort_order=[shuffle],
+            )
+
+        logger.info("Loaded {0} with #samples: {1}".format(split, len(dataset)))
+
+        self.datasets[split] = dataset
+        return self.datasets[split]
+
+    def build_model(self, cfg, from_checkpoint=False):
+        from fairseq import models
+
+        with open_dict(cfg) if OmegaConf.is_config(cfg) else contextlib.ExitStack():
+            cfg.max_positions = self.cfg.max_positions
+
+        model = models.build_model(cfg, self, from_checkpoint)
+        for index, num_class in enumerate(self.num_classes):
+            classification_head = f"{cfg.classification_head_name}{index}"
+            logger.info(f"Adding classification_head {classification_head}")
+            model.register_classification_head(classification_head, num_classes=num_class)
+
+        return model
+
+    def max_positions(self):
+        return self.cfg.max_positions
+
+    @property
+    def source_dictionary(self):
+        return self.dictionary
+
+    @property
+    def target_dictionary(self):
+        return self.dictionary
+
+    @property
+    def label_dictionary(self):
+        return self._label_dictionary

--- a/scripts/process_moleculenet.py
+++ b/scripts/process_moleculenet.py
@@ -4,6 +4,8 @@ import pandas as pd
 import argparse
 import os
 
+EMPTY_INDEX = -1
+
 p = argparse.ArgumentParser(description=__doc__,
                             formatter_class=argparse.RawDescriptionHelpFormatter)
 
@@ -28,6 +30,10 @@ if args.filter:
     nan_value = float("NaN")
     data_frame.replace("", nan_value, inplace=True)
     data_frame.dropna(subset=[data_frame.columns[args.class_index], data_frame.columns[args.smile_index]], inplace=True)
+else:
+    data_frame.replace("", EMPTY_INDEX, inplace=True)
+    data_frame.fillna(EMPTY_INDEX, inplace=True)
+
 
 print(data_frame)
 


### PR DESCRIPTION
## What does this PR do?

Implements multi-task classification prediction with the optional ability to ignore left out values.  To test both criterion and task should be set to `multi_sentence_prediction`.  `--num-classes = [3,3]` to the classes per prediction target, if has empty classes + 1, total number of targets `--number-of-targets = 2` and the string value of the value to ignore (not the index): `--ignore-str = -1`